### PR TITLE
Add helpful dev command with framework-specific paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "ci:lint": "prettier --check '**/*.{js,jsx,ts,tsx}'",
     "lint:fix": "prettier --write '**/*.{js,jsx,ts,tsx}'",
     "update-npm-dependency": "zx ./scripts/update-npm-dependency.mjs",
-    "g:changeset": "changeset"
+    "g:changeset": "changeset",
+    "dev": "echo 'This is a monorepo. Please run one of the following commands based on your needs:\\n- For SDK development: cd packages/sdks && yarn start\\n- For SDK tests: cd packages/sdks-tests && yarn dev\\n- For specific framework development:\\n  * React: cd packages/sdks && yarn start:react\\n  * Angular: cd packages/sdks && yarn start:angular\\n  * Vue: cd packages/sdks && yarn start:vue\\n  * Qwik: cd packages/sdks && yarn start:qwik\\n  * Solid: cd packages/sdks && yarn start:solid\\n  * React Native: cd packages/sdks && yarn start:reactNative\\n  * NextJS: cd packages/sdks && yarn start:rsc'"
   },
   "engines": {
     "yarn": ">= 3.0.0"


### PR DESCRIPTION
Adds a new `dev` script to package.json that provides clear guidance for developers on how to run different framework-specific development environments within the monorepo.

The script outputs instructions for:
- SDK development
- SDK tests
- Framework-specific development paths for:
  - React
  - Angular
  - Vue
  - Qwik
  - Solid
  - React Native
  - NextJS

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/fiddle?branchName=quantum-haven&projectId=512b7de30c7a4fa599882bee042b65ae)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>512b7de30c7a4fa599882bee042b65ae</projectId>-->