### PR TITLE
Add interactive dev menu script

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "lint:fix": "prettier --write '**/*.{js,jsx,ts,tsx}'",
     "update-npm-dependency": "zx ./scripts/update-npm-dependency.mjs",
     "g:changeset": "changeset",
-    "dev": "echo 'This is a monorepo. Please run one of the following commands based on your needs:\\n- For SDK development: cd packages/sdks && yarn start\\n- For SDK tests: cd packages/sdks-tests && yarn dev\\n- For specific framework development:\\n  * React: cd packages/sdks && yarn start:react\\n  * Angular: cd packages/sdks && yarn start:angular\\n  * Vue: cd packages/sdks && yarn start:vue\\n  * Qwik: cd packages/sdks && yarn start:qwik\\n  * Solid: cd packages/sdks && yarn start:solid\\n  * React Native: cd packages/sdks && yarn start:reactNative\\n  * NextJS: cd packages/sdks && yarn start:rsc'"
+    "dev": "echo 'This is a monorepo. Please run one of the following commands based on your needs:\\n- For SDK development: cd packages/sdks && yarn start\\n- For SDK tests: cd packages/sdks-tests && yarn dev\\n- For specific framework development:\\n  * React: cd packages/sdks && yarn start:react\\n  * Angular: cd packages/sdks && yarn start:angular\\n  * Vue: cd packages/sdks && yarn start:vue\\n  * Qwik: cd packages/sdks && yarn start:qwik\\n  * Solid: cd packages/sdks && yarn start:solid\\n  * React Native: cd packages/sdks && yarn start:reactNative\\n  * NextJS: cd packages/sdks && yarn start:rsc'",
+    "dev:menu": "node ./scripts/interactive-dev.mjs"
   },
   "engines": {
     "yarn": ">= 3.0.0"

--- a/scripts/interactive-dev.mjs
+++ b/scripts/interactive-dev.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+
+import { createInterface } from 'readline';
+
+const rl = createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+console.log('\n🏗️  Builder.io Monorepo Development Menu 🏗️\n');
+console.log('Select which part of the monorepo you want to work on:\n');
+console.log('1. SDK Development (packages/sdks)');
+console.log('2. SDK Tests (packages/sdks-tests)');
+console.log('3. React SDK');
+console.log('4. Angular SDK');
+console.log('5. Vue SDK');
+console.log('6. Qwik SDK');
+console.log('7. Solid SDK');
+console.log('8. React Native SDK');
+console.log('9. NextJS RSC SDK');
+console.log('0. Exit\n');
+
+rl.question('Enter your choice (0-9): ', answer => {
+  const choice = answer.trim();
+
+  const commands = {
+    1: 'cd packages/sdks && yarn start',
+    2: 'cd packages/sdks-tests && yarn dev',
+    3: 'cd packages/sdks && yarn start:react',
+    4: 'cd packages/sdks && yarn start:angular',
+    5: 'cd packages/sdks && yarn start:vue',
+    6: 'cd packages/sdks && yarn start:qwik',
+    7: 'cd packages/sdks && yarn start:solid',
+    8: 'cd packages/sdks && yarn start:reactNative',
+    9: 'cd packages/sdks && yarn start:rsc',
+    0: 'exit',
+  };
+
+  if (commands[choice]) {
+    const command = commands[choice];
+    console.log(`\nRunning: ${command}\n`);
+
+    if (choice === '0') {
+      console.log('Exiting interactive development menu.');
+      process.exit(0);
+    } else {
+      // For a real implementation, you'd use execSync or spawn to run the command
+      // but for this script we'll just show instructions
+      console.log('In your terminal, run the following command:');
+      console.log(`\n$ ${command}\n`);
+    }
+  } else {
+    console.log('Invalid choice. Please run the script again and select a valid option (0-9).');
+  }
+
+  rl.close();
+});


### PR DESCRIPTION
This PR adds an interactive CLI menu to improve developer experience when working with the monorepo.

Key changes:
- Added a new script `dev:menu` in package.json that runs the interactive menu
- Created a new file `scripts/interactive-dev.mjs` with a CLI interface that presents options for different SDK development environments
- The menu provides numbered options for various SDK development paths and displays the corresponding commands to run

The interactive menu makes it easier for developers to navigate the monorepo structure without having to remember specific commands.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/fiddle?branchName=spark-verse&projectId=b12f7083f24b4068a523010aa15813c7)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b12f7083f24b4068a523010aa15813c7</projectId>-->